### PR TITLE
Fix bugs with Advance, increase MoonPhase precision

### DIFF
--- a/TimeLord.h
+++ b/TimeLord.h
@@ -35,15 +35,16 @@ class TimeLord{
 		uint8_t LengthOfMonth(uint8_t *);
 		bool IsLeapYear(int);
 		
+                // these were private
+		void Adjust(uint8_t *, long);
+		long DayNumber(uint16_t, uint8_t, uint8_t);
+		bool InDst(uint8_t *);
 	private:
 		float latitude, longitude;
 		int timezone;
 		uint8_t dstm1, dstw1, dstm2, dstw2, dstadv;
-		void Adjust(uint8_t *, long);
 		bool ComputeSun(uint8_t *, bool);
 		char Signum(int);
 		int Absolute(int);
-		long DayNumber(uint16_t, uint8_t, uint8_t);
-		bool InDst(uint8_t *);
 		uint8_t _season(uint8_t *);
 };


### PR DESCRIPTION
TimeLord::MoonPhase - take fractional day into account when returning moon
phase.  This probably isn't super accurate, but it makes for a much smoother
transition when drawing a moon based on the results from MoonPaase.

TimeLord::Adjust - had bugs when advancing by more than a day, especially
around month boundaries. I don't know if the advance backwards is
fully correct (I wouldn't bet money on it, but I don't need that code -- left
as an exercise to the reader)

TimeLord.h:
made Adjust(), DayNumber(), and InDst() public -- don't see any reason
not to, and I need them outside of the library.  _season() might probably
a good candidate, too.