### PR TITLE
Fix compile error in Linux

### DIFF
--- a/TimeLord.cpp
+++ b/TimeLord.cpp
@@ -1,7 +1,7 @@
 extern "C" {
 
 	#include <inttypes.h>
-	#include <Math.h>
+	#include <math.h>
 }
 
 #include "TimeLord.h"

--- a/TimeLord.h
+++ b/TimeLord.h
@@ -1,7 +1,7 @@
 extern "C" {
 
 	#include <inttypes.h>
-	#include <Math.h>
+	#include <math.h>
 }
 
 #define tl_second 0


### PR DESCRIPTION
Windows is not case sensitive for directory and file names so this library compiles but it fails to compile in Linux because it should be math.h with a lowercase M.